### PR TITLE
Add CPLD register cache and gain-to-ATT mapping for kintex7sdr RX

### DIFF
--- a/host/lib/usrp/dboard/db_kintex7sdr/cpld_regmap.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/cpld_regmap.hpp
@@ -30,6 +30,11 @@ enum reg_t : uint8_t {
     REG_STATUS     = 0x04  // sticky flags / status
 };
 
+// REG_CTRL bit definitions (должны совпадать с regmap_core)
+static constexpr uint32_t CTRL_ATT1_C1  = (1u << 0);
+static constexpr uint32_t CTRL_ATT1_C2  = (1u << 1);
+static constexpr uint32_t CTRL_ATT1_MASK = (CTRL_ATT1_C1 | CTRL_ATT1_C2);
+
 // Упаковка 32-битного слова под наш CPLD SPI engine: [CMD][DATA24]
 // CMD: bit7 = 1 write / 0 read, bits[6:0] = reg
 static inline uint32_t make_cmd(const bool is_write, const uint8_t reg7)

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
@@ -3,6 +3,7 @@
 #include <uhd/usrp/dboard_manager.hpp>
 #include <uhd/utils/static.hpp>
 
+#include <array>
 #include <chrono>
 #include <functional>
 #include <iomanip>
@@ -20,6 +21,15 @@ static const uhd::gain_range_t KINTEX7SDR_RX_GAIN_RANGE(0.0, 31.5, 0.5);
 // На большинстве dboard-дизайнов "ничего не выбрано" для 3-битного SPI_ADDR = 0b111.
 // Если в твоём CPLD другое соглашение — поменяй здесь.
 static const uint32_t SPI_DEST_NONE_3B = 0x7u;
+
+static const std::array<db_kintex7sdr_rx::gain_profile, 6> KINTEX7SDR_GAIN_TABLE{{
+    {0.0,  0b00, 0x00},
+    {6.0,  0b01, 0x10},
+    {12.0, 0b10, 0x20},
+    {18.0, 0b11, 0x30},
+    {24.0, 0b11, 0x40},
+    {30.0, 0b11, 0x50},
+}};
 
 // ============================================================================
 // db_kintex7sdr_rx
@@ -234,7 +244,32 @@ uint32_t db_kintex7sdr_rx::_spi_xfer_to(uint32_t dest3, uint32_t word, size_t nb
 
 void db_kintex7sdr_rx::_cpld_wr(uint8_t reg7, uint32_t data24)
 {
-    (void)_spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_wr(reg7, data24), 32);
+    const uint32_t data = data24 & 0x00FFFFFFu;
+    std::lock_guard<std::mutex> lock(_cpld_mutex);
+    auto& entry = _cpld_cache[reg7];
+    if (entry.valid && entry.value == data) {
+        return;
+    }
+
+    (void)_spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_wr(reg7, data), 32);
+    entry.value = data;
+    entry.valid = true;
+}
+
+void db_kintex7sdr_rx::_cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value)
+{
+    uint32_t base = 0;
+    {
+        std::lock_guard<std::mutex> lock(_cpld_mutex);
+        auto it = _cpld_cache.find(reg7);
+        if (it != _cpld_cache.end() && it->second.valid) {
+            base = it->second.value;
+        }
+    }
+
+    // Если кэш пустой, считаем базовое значение 0 и пишем только mask-биты.
+    const uint32_t next = (base & ~mask) | (value & mask);
+    _cpld_wr(reg7, next);
 }
 
 uint16_t db_kintex7sdr_rx::_ltc5594_xfer16(uint16_t w)
@@ -277,9 +312,28 @@ double db_kintex7sdr_rx::set_rx_frequency(double freq)
 
 double db_kintex7sdr_rx::set_rx_gain(double gain)
 {
-    // TODO:
-    //  - перевести gain (dB) в коды аттенюаторов/усилителей
-    //  - записать CPLD регистры или GPIO
+    // ВНИМАНИЕ: соответствие битов REG_CTRL и карт усиления должно
+    // совпадать с regmap_core в CPLD.
+    gain = KINTEX7SDR_RX_GAIN_RANGE.clip(gain);
+
+    const gain_profile* profile = &KINTEX7SDR_GAIN_TABLE.front();
+    for (const auto& entry : KINTEX7SDR_GAIN_TABLE) {
+        if (gain >= entry.gain_db) {
+            profile = &entry;
+        }
+    }
+
+    uint32_t att1_value = 0;
+    if (profile->att1_code & 0x2) {
+        att1_value |= cpld::CTRL_ATT1_C1;
+    }
+    if (profile->att1_code & 0x1) {
+        att1_value |= cpld::CTRL_ATT1_C2;
+    }
+
+    _cpld_update_bits(cpld::REG_CTRL, cpld::CTRL_ATT1_MASK, att1_value);
+    _cpld_wr(cpld::REG_ATT2_CODE, profile->att2_code);
+
     _rx_gain = gain;
     return _rx_gain;
 }

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
@@ -60,6 +60,17 @@ private:
         uint32_t ddr;
     };
 
+    struct cpld_cache_entry {
+        uint32_t value;
+        bool valid;
+    };
+
+    struct gain_profile {
+        double gain_db;
+        uint8_t att1_code;
+        uint8_t att2_code;
+    };
+
     // GPIO helpers
     void _init_gpio_map();
     void _set_gpio_field(gpio_field_id id, uint32_t v);
@@ -92,6 +103,7 @@ private:
 
     // Chip-level xfers
     void     _cpld_wr(uint8_t reg7, uint32_t data24);
+    void     _cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value);
     uint16_t _ltc5594_xfer16(uint16_t w);
     uint16_t _ltc6948_xfer16(uint16_t w);
 
@@ -100,9 +112,11 @@ private:
     uhd::spi_config_t _spi_cfg;
 
     std::mutex _spi_mutex;
+    std::mutex _cpld_mutex;
 
     std::map<gpio_field_id, gpio_field_info> _gpio_map;
     gpio_reg_cache _rx_gpio;
+    std::map<uint8_t, cpld_cache_entry> _cpld_cache;
 
     // кэш текущего SPI destination (чтобы не дёргать GPIO каждый раз)
     bool _spi_dest_valid{false};


### PR DESCRIPTION
### Motivation

- Avoid redundant SPI transactions to the CPLD by caching written register values and skipping no-op writes.
- Provide a safe read-modify-write helper for updating individual bits in CPLD registers under a mutex.
- Expose CPLD control bit definitions so host-side code and CPLD logic share the same bit semantics.
- Map user-facing RX gain to ATT1/ATT2 control codes so `set_rx_gain` programs the hardware consistently.

### Description

- Added `cpld_cache_entry`, `_cpld_cache`, and `_cpld_mutex` and updated `_cpld_wr` to mask to 24 bits, cache writes, and skip identical writes in `db_kintex7sdr.cpp`/`.hpp`.
- Implemented `_cpld_update_bits` helper that performs a read-from-cache, compute-and-write masked update using `_cpld_wr`.
- Introduced `CTRL_ATT1_C1`, `CTRL_ATT1_C2`, and `CTRL_ATT1_MASK` constants in `cpld_regmap.hpp` to match CPLD `regmap_core` semantics.
- Added `gain_profile` and `KINTEX7SDR_GAIN_TABLE` and implemented `set_rx_gain` to select a profile and program `REG_CTRL` and `REG_ATT2_CODE` via `_cpld_update_bits`/`_cpld_wr`.

### Testing

- No automated tests were executed for this change.
- Changes were limited to host-side driver code and header definitions and were committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696180307474832cbcaa36bf21fc3bf0)