### PR TITLE
Add integer‑N LO skeleton for LTC6948 and RX frequency quantization

### DIFF
--- a/host/lib/usrp/dboard/db_kintex7sdr/cpld_regmap.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/cpld_regmap.hpp
@@ -30,6 +30,11 @@ enum reg_t : uint8_t {
     REG_STATUS     = 0x04  // sticky flags / status
 };
 
+// REG_CTRL bit definitions (должны совпадать с regmap_core)
+static constexpr uint32_t CTRL_ATT1_C1  = (1u << 0);
+static constexpr uint32_t CTRL_ATT1_C2  = (1u << 1);
+static constexpr uint32_t CTRL_ATT1_MASK = (CTRL_ATT1_C1 | CTRL_ATT1_C2);
+
 // Упаковка 32-битного слова под наш CPLD SPI engine: [CMD][DATA24]
 // CMD: bit7 = 1 write / 0 read, bits[6:0] = reg
 static inline uint32_t make_cmd(const bool is_write, const uint8_t reg7)

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
@@ -3,7 +3,9 @@
 #include <uhd/usrp/dboard_manager.hpp>
 #include <uhd/utils/static.hpp>
 
+#include <array>
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <iomanip>
 #include <sstream>
@@ -20,6 +22,15 @@ static const uhd::gain_range_t KINTEX7SDR_RX_GAIN_RANGE(0.0, 31.5, 0.5);
 // На большинстве dboard-дизайнов "ничего не выбрано" для 3-битного SPI_ADDR = 0b111.
 // Если в твоём CPLD другое соглашение — поменяй здесь.
 static const uint32_t SPI_DEST_NONE_3B = 0x7u;
+
+static const std::array<db_kintex7sdr_rx::gain_profile, 6> KINTEX7SDR_GAIN_TABLE{{
+    {0.0,  0b00, 0x00},
+    {6.0,  0b01, 0x10},
+    {12.0, 0b10, 0x20},
+    {18.0, 0b11, 0x30},
+    {24.0, 0b11, 0x40},
+    {30.0, 0b11, 0x50},
+}};
 
 // ============================================================================
 // db_kintex7sdr_rx
@@ -234,7 +245,32 @@ uint32_t db_kintex7sdr_rx::_spi_xfer_to(uint32_t dest3, uint32_t word, size_t nb
 
 void db_kintex7sdr_rx::_cpld_wr(uint8_t reg7, uint32_t data24)
 {
-    (void)_spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_wr(reg7, data24), 32);
+    const uint32_t data = data24 & 0x00FFFFFFu;
+    std::lock_guard<std::mutex> lock(_cpld_mutex);
+    auto& entry = _cpld_cache[reg7];
+    if (entry.valid && entry.value == data) {
+        return;
+    }
+
+    (void)_spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_wr(reg7, data), 32);
+    entry.value = data;
+    entry.valid = true;
+}
+
+void db_kintex7sdr_rx::_cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value)
+{
+    uint32_t base = 0;
+    {
+        std::lock_guard<std::mutex> lock(_cpld_mutex);
+        auto it = _cpld_cache.find(reg7);
+        if (it != _cpld_cache.end() && it->second.valid) {
+            base = it->second.value;
+        }
+    }
+
+    // Если кэш пустой, считаем базовое значение 0 и пишем только mask-биты.
+    const uint32_t next = (base & ~mask) | (value & mask);
+    _cpld_wr(reg7, next);
 }
 
 uint16_t db_kintex7sdr_rx::_ltc5594_xfer16(uint16_t w)
@@ -261,25 +297,67 @@ void db_kintex7sdr_rx::log_ltc5594_chip_id()
     UHD_LOG_INFO("DB_KINTEX7SDR_RX", oss.str());
 }
 
+void db_kintex7sdr_rx::_program_ltc6948_integer_n(uint16_t n_div, uint8_t r_div)
+{
+    // TODO: заполнить правильные регистры LTC6948 для N/R после проверки datasheet.
+    // Здесь оставляем скелет — только логируем вычисленные значения.
+    std::ostringstream oss;
+    oss << "LTC6948 integer-N settings: N=" << n_div << " R=" << unsigned(r_div);
+    UHD_LOG_INFO("DB_KINTEX7SDR_RX", oss.str());
+}
+
 // ============================================================================
 // UHD coercers (пока заглушки)
 // ============================================================================
 
 double db_kintex7sdr_rx::set_rx_frequency(double freq)
 {
-    // TODO:
-    //  - рассчитать настройки LTC6948 (N/R/FRAC) под требуемую LO
-    //  - запрограммировать regs через _ltc6948_xfer16(ltc6948::make_word_wr(...))
-    //  - при необходимости управлять делителями/фильтрами через CPLD
+    constexpr double k_min_freq = 300e6;
+    constexpr double k_max_freq = 2200e6;
+    constexpr double k_step_hz = 1e6;
+    constexpr double k_ref_hz = 100e6;
+
+    if (freq < k_min_freq) {
+        freq = k_min_freq;
+    } else if (freq > k_max_freq) {
+        freq = k_max_freq;
+    }
+
+    freq = std::round(freq / k_step_hz) * k_step_hz;
+
+    const auto n_div = static_cast<uint16_t>(std::round(freq / k_ref_hz));
+    const uint8_t r_div = 1;
+
+    _program_ltc6948_integer_n(n_div, r_div);
+
     _rx_freq = freq;
     return _rx_freq;
 }
 
 double db_kintex7sdr_rx::set_rx_gain(double gain)
 {
-    // TODO:
-    //  - перевести gain (dB) в коды аттенюаторов/усилителей
-    //  - записать CPLD регистры или GPIO
+    // ВНИМАНИЕ: соответствие битов REG_CTRL и карт усиления должно
+    // совпадать с regmap_core в CPLD.
+    gain = KINTEX7SDR_RX_GAIN_RANGE.clip(gain);
+
+    const gain_profile* profile = &KINTEX7SDR_GAIN_TABLE.front();
+    for (const auto& entry : KINTEX7SDR_GAIN_TABLE) {
+        if (gain >= entry.gain_db) {
+            profile = &entry;
+        }
+    }
+
+    uint32_t att1_value = 0;
+    if (profile->att1_code & 0x2) {
+        att1_value |= cpld::CTRL_ATT1_C1;
+    }
+    if (profile->att1_code & 0x1) {
+        att1_value |= cpld::CTRL_ATT1_C2;
+    }
+
+    _cpld_update_bits(cpld::REG_CTRL, cpld::CTRL_ATT1_MASK, att1_value);
+    _cpld_wr(cpld::REG_ATT2_CODE, profile->att2_code);
+
     _rx_gain = gain;
     return _rx_gain;
 }

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
@@ -60,6 +60,17 @@ private:
         uint32_t ddr;
     };
 
+    struct cpld_cache_entry {
+        uint32_t value;
+        bool valid;
+    };
+
+    struct gain_profile {
+        double gain_db;
+        uint8_t att1_code;
+        uint8_t att2_code;
+    };
+
     // GPIO helpers
     void _init_gpio_map();
     void _set_gpio_field(gpio_field_id id, uint32_t v);
@@ -92,17 +103,21 @@ private:
 
     // Chip-level xfers
     void     _cpld_wr(uint8_t reg7, uint32_t data24);
+    void     _cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value);
     uint16_t _ltc5594_xfer16(uint16_t w);
     uint16_t _ltc6948_xfer16(uint16_t w);
+    void     _program_ltc6948_integer_n(uint16_t n_div, uint8_t r_div);
 
 private:
     uhd::usrp::dboard_iface::sptr _iface;
     uhd::spi_config_t _spi_cfg;
 
     std::mutex _spi_mutex;
+    std::mutex _cpld_mutex;
 
     std::map<gpio_field_id, gpio_field_info> _gpio_map;
     gpio_reg_cache _rx_gpio;
+    std::map<uint8_t, cpld_cache_entry> _cpld_cache;
 
     // кэш текущего SPI destination (чтобы не дёргать GPIO каждый раз)
     bool _spi_dest_valid{false};


### PR DESCRIPTION
### Motivation

- Provide a minimal integer‑N programming path for the LTC6948 LO so host coercers can compute and hand off N/R settings without trying fractional math.  
- Enforce the requested RX frequency limits and step resolution of 300–2200 MHz with 1 MHz steps and a 100 MHz reference.  
- Avoid redundant CPLD SPI writes by caching register values and expose CPLD control bit semantics so host and CPLD logic agree.  
- Expose a simple mapping from user gain (dB) to ATT1/ATT2 control codes for deterministic host-side gain programming.

### Description

- Added the prototype `void _program_ltc6948_integer_n(uint16_t n_div, uint8_t r_div);` to `db_kintex7sdr.hpp` and implemented a logging stub in `db_kintex7sdr.cpp` that accepts integer `N` and `R` but does not yet program LTC6948 registers.  
- Implemented RX frequency clamping and quantization in `set_rx_frequency` to the 300–2200 MHz range with 1 MHz steps and a 100 MHz reference, computed `N = round(freq / 100e6)` and called `_program_ltc6948_integer_n`.  
- Added CPLD write caching and a safe masked update helper via `_cpld_wr` and `_cpld_update_bits` to skip no‑op SPI writes, plus `CTRL_ATT1_C1`, `CTRL_ATT1_C2`, and `CTRL_ATT1_MASK` in `cpld_regmap.hpp`.  
- Introduced a `gain_profile` table and logic in `set_rx_gain` to map requested gain to ATT1/ATT2 codes and program `REG_CTRL`/`REG_ATT2_CODE` via the new CPLD helpers.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696180307474832cbcaa36bf21fc3bf0)