### PR TITLE
Fix CPLD masked writes and PLL divisor calculation

### DIFF
--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
@@ -257,18 +257,34 @@ void db_kintex7sdr_rx::_cpld_wr(uint8_t reg7, uint32_t data24)
     entry.valid = true;
 }
 
+uint32_t db_kintex7sdr_rx::_cpld_rd(uint8_t reg7)
+{
+    const uint32_t rx = _spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_rd(reg7), 32);
+    const uint32_t data = rx & 0x00FFFFFFu;
+    std::lock_guard<std::mutex> lock(_cpld_mutex);
+    auto& entry = _cpld_cache[reg7];
+    entry.value = data;
+    entry.valid = true;
+    return data;
+}
+
 void db_kintex7sdr_rx::_cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value)
 {
     uint32_t base = 0;
+    bool cache_valid = false;
     {
         std::lock_guard<std::mutex> lock(_cpld_mutex);
         auto it = _cpld_cache.find(reg7);
         if (it != _cpld_cache.end() && it->second.valid) {
             base = it->second.value;
+            cache_valid = true;
         }
     }
 
-    // Если кэш пустой, считаем базовое значение 0 и пишем только mask-биты.
+    if (!cache_valid) {
+        base = _cpld_rd(reg7);
+    }
+
     const uint32_t next = (base & ~mask) | (value & mask);
     _cpld_wr(reg7, next);
 }
@@ -355,7 +371,6 @@ double db_kintex7sdr_rx::set_rx_frequency(double freq)
         r_div = 1.0;
     }
 
-    auto n_div = static_cast<uint16_t>(std::round((freq * r_div) / k_ref_hz));
     auto r_div_u8 = static_cast<uint8_t>(r_div);
 
     if (r_div_u8 < 1) {
@@ -363,6 +378,8 @@ double db_kintex7sdr_rx::set_rx_frequency(double freq)
     } else if (r_div_u8 > 31) {
         r_div_u8 = 31;
     }
+
+    auto n_div = static_cast<uint16_t>(std::round((freq * r_div_u8) / k_ref_hz));
 
     if (n_div < 32) {
         n_div = 32;

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
@@ -102,6 +102,7 @@ private:
     uint32_t _spi_xfer_to(uint32_t dest3, uint32_t word, size_t nbits);
 
     // Chip-level xfers
+    uint32_t _cpld_rd(uint8_t reg7);
     void     _cpld_wr(uint8_t reg7, uint32_t data24);
     void     _cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value);
     uint16_t _ltc5594_xfer16(uint16_t w);


### PR DESCRIPTION
### Motivation
- Prevent `_cpld_update_bits` from inadvertently clearing other CPLD register bits when the cache is not populated. 
- Preserve CPLD control bits that may exist outside of the masked region used for attenuation updates. 
- Ensure PLL frequency math remains correct when the R divider is clamped to the hardware range. 

### Description
- Add `uint32_t _cpld_rd(uint8_t reg7)` declaration and implement `_cpld_rd` to read back 24-bit CPLD register data and update the `_cpld_cache`. 
- Change `_cpld_update_bits` to track cache validity (`cache_valid`) and call `_cpld_rd` when the cache entry is missing instead of assuming a base value of `0`, then write `(base & ~mask) | (value & mask)`. 
- Recompute `n_div` after clamping `r_div` to the `1..31` range by using the clamped `r_div_u8` in the `n_div` calculation, then clamp `n_div` to `32..1023` and program the PLL with `_program_ltc6948_integer_n(n_div, r_div_u8)`. 
- Add the `_cpld_rd` prototype to the header file. 

### Testing
- No automated tests or continuous-integration jobs were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69622f454ad4832cba8e36dd9538432e)