### PR TITLE
Expose gain_profile for static table; add CPLD read and PLL math fix

### DIFF
--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.cpp
@@ -257,18 +257,34 @@ void db_kintex7sdr_rx::_cpld_wr(uint8_t reg7, uint32_t data24)
     entry.valid = true;
 }
 
+uint32_t db_kintex7sdr_rx::_cpld_rd(uint8_t reg7)
+{
+    const uint32_t rx = _spi_xfer_to(uint32_t(cpld::SPI_DEST_CPLD), cpld::make_frame_rd(reg7), 32);
+    const uint32_t data = rx & 0x00FFFFFFu;
+    std::lock_guard<std::mutex> lock(_cpld_mutex);
+    auto& entry = _cpld_cache[reg7];
+    entry.value = data;
+    entry.valid = true;
+    return data;
+}
+
 void db_kintex7sdr_rx::_cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value)
 {
     uint32_t base = 0;
+    bool cache_valid = false;
     {
         std::lock_guard<std::mutex> lock(_cpld_mutex);
         auto it = _cpld_cache.find(reg7);
         if (it != _cpld_cache.end() && it->second.valid) {
             base = it->second.value;
+            cache_valid = true;
         }
     }
 
-    // Если кэш пустой, считаем базовое значение 0 и пишем только mask-биты.
+    if (!cache_valid) {
+        base = _cpld_rd(reg7);
+    }
+
     const uint32_t next = (base & ~mask) | (value & mask);
     _cpld_wr(reg7, next);
 }
@@ -355,7 +371,6 @@ double db_kintex7sdr_rx::set_rx_frequency(double freq)
         r_div = 1.0;
     }
 
-    auto n_div = static_cast<uint16_t>(std::round((freq * r_div) / k_ref_hz));
     auto r_div_u8 = static_cast<uint8_t>(r_div);
 
     if (r_div_u8 < 1) {
@@ -363,6 +378,8 @@ double db_kintex7sdr_rx::set_rx_frequency(double freq)
     } else if (r_div_u8 > 31) {
         r_div_u8 = 31;
     }
+
+    auto n_div = static_cast<uint16_t>(std::round((freq * r_div_u8) / k_ref_hz));
 
     if (n_div < 32) {
         n_div = 32;

--- a/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
+++ b/host/lib/usrp/dboard/db_kintex7sdr/db_kintex7sdr.hpp
@@ -36,6 +36,12 @@ public:
     // helper: чтение CHIPID LTC5594 и лог в UHD
     void log_ltc5594_chip_id();
 
+    struct gain_profile {
+        double gain_db;
+        uint8_t att1_code;
+        uint8_t att2_code;
+    };
+
 private:
     // GPIO fields (минимум нужного сейчас)
     enum gpio_field_id : uint8_t {
@@ -63,12 +69,6 @@ private:
     struct cpld_cache_entry {
         uint32_t value;
         bool valid;
-    };
-
-    struct gain_profile {
-        double gain_db;
-        uint8_t att1_code;
-        uint8_t att2_code;
     };
 
     // GPIO helpers
@@ -102,6 +102,7 @@ private:
     uint32_t _spi_xfer_to(uint32_t dest3, uint32_t word, size_t nbits);
 
     // Chip-level xfers
+    uint32_t _cpld_rd(uint8_t reg7);
     void     _cpld_wr(uint8_t reg7, uint32_t data24);
     void     _cpld_update_bits(uint8_t reg7, uint32_t mask, uint32_t value);
     uint16_t _ltc5594_xfer16(uint16_t w);


### PR DESCRIPTION
### Motivation
- Fix a compile error where a file-scope static gain table referenced `db_kintex7sdr_rx::gain_profile` which was declared `private`.
- Prevent CPLD masked writes from clearing unrelated bits when the local cache entry is missing or invalid.
- Ensure PLL divisor math uses the clamped `R` divider when computing the integer `N` value for the LTC6948.
- Provide a header prototype for the new CPLD read helper so it can be used by other member functions.

### Description
- Move `struct gain_profile` into the `public` section of `db_kintex7sdr_rx` so file-scope tables can use it.
- Implement `uint32_t db_kintex7sdr_rx::_cpld_rd(uint8_t reg7)` to read back 24-bit CPLD register data via SPI and update `_cpld_cache`.
- Update `_cpld_update_bits` to detect cache validity and call `_cpld_rd` when the cache is missing instead of assuming a base value of `0`, then write `(base & ~mask) | (value & mask)`.
- Recompute `n_div` after clamping `r_div` into the `1..31` hardware range by using the clamped `r_div_u8`, then clamp `n_div` to `32..1023` and program the PLL with `_program_ltc6948_integer_n(n_div, r_div_u8)`.
- Add the `_cpld_rd` prototype to the header file.

### Testing
- A `make` run before the header fix failed with a compilation error complaining that `gain_profile` was private.
- No automated tests or CI jobs were run after applying these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69622f454ad4832cba8e36dd9538432e)